### PR TITLE
Fix markdown issue in spa-with-cro.md

### DIFF
--- a/docs/intro/spa-with-cro.md
+++ b/docs/intro/spa-with-cro.md
@@ -880,7 +880,7 @@ post -> 'tips' {
         response.status = 204;
     }
 }
-``` 
+```
 
 Next up, the JavaScript part. The question is where to put the network bit?
 Our reducer should be pure. The answer is the `redux-thunk` module that we


### PR DESCRIPTION
This is what it currently looks like for me:

![image](https://user-images.githubusercontent.com/199499/32495263-3e8470dc-c3c5-11e7-993b-e65e9285c097.png)
