### PR TITLE
Copyedit minor nits in docs/{,intro/}*.md

### DIFF
--- a/docs/approach.md
+++ b/docs/approach.md
@@ -8,23 +8,23 @@ over the network.
 
 Messages are represented by `Cro::Message`. Concrete implementations include:
 
-* Cro::TCP::Message
-* Cro::HTTP::Request
-* Cro::HTTP::Response
+* `Cro::TCP::Message`
+* `Cro::HTTP::Request`
+* `Cro::HTTP::Response`
 
 Incoming connections are represented by `Cro::Connection`; implementations
 include:
 
-* Cro::TCP::ServerConnection
-* Cro::TLS::ServerConnection
+* `Cro::TCP::ServerConnection`
+* `Cro::TLS::ServerConnection`
 
 A `Cro::Source` is a source of either messages or connections. For example,
 `Cro::TCP::Listener` produces `Cro::TCP::ServerConnection` objects.
 
 A `Cro::Transform` transforms one connection or message into another. For
 example, `Cro::HTTP::RequestParser` will transform `Cro::TCP::Message`s into
-`Cro::HTTP::Request`s, while a `Cro::HTTP::ResponseSerializer` transforms a
-`Cro::HTTP::Response`s into `Cro::TCP::Messages`s. This means that in Cro,
+`Cro::HTTP::Request`s, while a `Cro::HTTP::ResponseSerializer` transforms
+`Cro::HTTP::Response`s into `Cro::TCP::Message`s. This means that in Cro,
 HTTP applications are simply transforms from `Cro::HTTP::Request` into
 `Cro::HTTP::Response`.
 
@@ -153,7 +153,7 @@ A minimal TCP client that connects, sends a message, and disconnects as soon
 as it has received something, could be expressed as:
 
     my Cro::Connector $conn = Cro.compose(Cro::TCP::Connector);
-    my Supply $responses = $tcp-client.establish(
+    my Supply $responses = $conn.establish(
         host => 'localhost',
         port => 4242,
         supply {

--- a/docs/cro-tool.md
+++ b/docs/cro-tool.md
@@ -11,14 +11,14 @@ project.
 A new service can be stubbed using the `cro stub` command. The general usage
 is:
 
-    cro stub <service-type> <service-id> <path> ['link-and-options']
+    cro stub <service-type> <service-id> <path> ['links-and-options']
 
 Where
 
 * `service-type` is the type of service to create
 * `service-id` is the ID of the service (to be used with other `cro`
   commands; this will also be used as the service's default descriptive
-  `name` in `.cro.yml`),
+  `name` in `.cro.yml`)
 * `path` is the location to create the service
 * `links-and-options` specifies links to other services that should be added
   to the stub, together with options specific to the service type
@@ -47,14 +47,14 @@ of an entry in the `endpoints` list of that `.cro.yml` file.
 ### HTTP Services
 
 The `http` service type stubs in a HTTP service, using `Cro::HTTP::Router` and
-served by `Cro::HTTP::Server`. By default, it stubs a HTTPS service that will
+served by `Cro::HTTP::Server`. By default, it stubs an HTTPS service that will
 accept HTTP/1.0, HTTP/1.1 and HTTP/2.0 requests.
 
     cro stub http flashcard-backend backend/flashcards
 
 The following options may be supplied:
 
-* `:secure`: generates a HTTPS service instead of a HTTP one (`:!secure` is
+* `:secure`: generates an HTTPS service instead of an HTTP one (`:!secure` is
   the default); implies `:http1 :http2` by default, using ALPN to negotiate
   whether to use HTTP/2
 * `:!http2`: generates a service without HTTP 2 support
@@ -139,7 +139,7 @@ An IP address to bind to may also be provided before the port number:
 ## Working with service links
 
 The `cro link` subcommand is used to manage the `links` section of `.cro.yml`
-files. These describes how one Cro service uses another, resulting in the
+files. These describe how one Cro service uses another, resulting in the
 injection of environment variables specifying the host and port where the
 service can be found. In production, these would be set by a container engine
 such as Kubernetes, by some kind of configuration management system, or even
@@ -161,7 +161,7 @@ If `to-endpoint-id` is not specified, and the `to-service-id` service has only
 one endpoint, then that one will be used by default. Otherwise, the ambiguity
 will be whined about.
 
-To re-generate the code for an existing link, do:
+To regenerate the code for an existing link, do:
 
     cro link code <from-service-id> <to-service-id> [<to-endpoint-id>]
 

--- a/docs/cro-yml.md
+++ b/docs/cro-yml.md
@@ -73,7 +73,7 @@ from another service. Protocols include:
 * `http` - HTTP/1.1 insecure
 * `http2` - HTTP/2.0 insecure (starts HTTP/2 by prior knowledge)
 * `wss` - web socket secure
-* `ws` - insecure
+* `ws` - web socket insecure
 * `zeromq/rep` - ZeroMQ `REP` (generated client would be a `REQ`)
 * `zeromq/pub` - ZeroMQ `PUB` (generated client would be a `SUB`)
 
@@ -109,7 +109,7 @@ links:
 Where `service` is the ID of the service (defined by `id` in its `.cro.yml`),
 `endpoint` is the ID of the endpoint (from the target service's `.cro.yml`'s
 `endpoints` section), and `env` is the environment variable specifying the
-host and port in the form `host:port`
+host and port in the form `host:port`.
 
 ## Environment
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 ## Introductory Material
 
-The essentials you need to know to get building with Cro.
+The essentials you need to know to get building with Cro:
 
 * [Getting Started](docs/intro/getstarted)
 * [Creating HTTP Services](docs/intro/http-server)
@@ -12,7 +12,7 @@ The essentials you need to know to get building with Cro.
 ## Beyond The Basics
 
 Ready to dig a deeper? These articles explain the Cro design and structure,
-as well as covering some more advanced topics.
+as well as covering some more advanced topics:
 
 * [The Cro Approach](docs/approach)
 * [Module Structure](docs/module-structure)
@@ -21,7 +21,7 @@ as well as covering some more advanced topics.
 
 ## Reference
 
-The full details, organized by module.
+The full details, organized by module:
 
 ### Cro::Core
 
@@ -76,7 +76,7 @@ Pipeline components:
 
 The development tools are mostly without API docs, as they are mostly not
 expected to be extended from the outside at this point. However, the following
-parts have stable APIs for the sake of extending the tools.
+parts have stable APIs for the sake of extending the tools:
 
 * [Cro::Tools::LinkTemplate](docs/reference/cro-tools-linktemplate)
 * [Cro::Tools::Template](docs/reference/cro-tools-template)

--- a/docs/intro/getstarted.md
+++ b/docs/intro/getstarted.md
@@ -5,7 +5,7 @@ Here's a list of things to do to get Cro running on your machine.
 ## Install Perl 6
 
 Cro services are written in Perl 6; if you have not yet installed that,
-[see this instructions](https://perl6.org/downloads/). Note that you will
+[see these instructions](https://perl6.org/downloads/). Note that you will
 need a fairly modern Perl 6; the ones included in packages can be very old.
 
 Provided you install Perl 6 using Rakudo Star, the `zef` module manager will
@@ -61,7 +61,7 @@ There should now be a page saying 'Hello Cro!' at http://localhost:10000
 
 Congratulations, you have successfully installed Cro!
 
-Now learn more about [building a HTTP service](http-server).
+Now learn more about [building an HTTP service](http-server).
 
 ## Extra credit: use `cro stub` and `cro run`
 

--- a/docs/intro/http-client.md
+++ b/docs/intro/http-client.md
@@ -9,7 +9,7 @@ The simplest `GET` request can be written as:
 # Import the client class.
 use Cro::HTTP::Client;
 
-# Doing the request
+# Make the request
 my $resp = await Cro::HTTP::Client.get('https://www.perl6.org/');
 ```
 

--- a/docs/intro/http-server.md
+++ b/docs/intro/http-server.md
@@ -66,6 +66,6 @@ react whenever signal(SIGINT) {
 }
 ```
 
-And the application is up and running, so it's time to improve it: add
+With this the application is up and running, so it's time to improve it: add
 more logic and use other features. See `Cro::HTTP::Router` and
 `Cro::HTTP::Server` to learn more.

--- a/docs/intro/spa-with-cro.md
+++ b/docs/intro/spa-with-cro.md
@@ -30,7 +30,7 @@ So, we'll make a SPA that supports:
 
 * Submitting new tips (a POST to the backend)
 * Having the latest tips appear live (delivered over a web socket)
-* Being able to agree to disagree with a tip (also a POST)
+* Being able to agree or disagree with a tip (also a POST)
 * Being able to see a list of the tips sorted most agreeable to most
   disagreeable (obtained by a `GET`)
 
@@ -244,7 +244,7 @@ bundle.js  2.5 kB       0  [emitted]  main
 
 ## Serving and using the bundle
 
-Next up, edit `static/index.html`, and just before the closing </body> tag
+Next up, edit `static/index.html`, and just before the closing `</body>` tag
 add:
 
 ```
@@ -285,7 +285,7 @@ ways we could factor it, but the key thing to keep in mind is that a web
 application is a concurrent system, and in Cro requests are processed on a
 thread pool. This means two requests may be processed at the same time!
 
-To handle this, we'll use the OO::Monitors module. A monitor is like a class,
+To handle this, we'll use the `OO::Monitors` module. A monitor is like a class,
 but it enforces mutual exclusion on its methods - that is, only one thread
 may be inside the methods on a particular instance at a time. Thus, provided
 we don't leak out our internal state (making defensive copies if we do have
@@ -343,8 +343,8 @@ that, we'll come back to them one at a time.
 
 Next up is to make this available to our routes. We could make the instance in
 `Routes.pm6`, but that will make it hard to test our routes in isolation of
-the business logic. Instead, we'll make the sub in Routes.pm6 take an instance
-of the business logic object as parameter:
+the business logic. Instead, we'll make the sub in `Routes.pm6` take an instance
+of the business logic object as a parameter:
 
 ```
 use Cro::HTTP::Router;
@@ -432,7 +432,7 @@ done-testing;
 
 The first part tests that we can add two tips, and that if we tap the `Supply`
 of latest tips then we are given those two straight away. The second part is a
-bit more involved: it checks that if we tap the latest tips Supply, and then a
+bit more involved: it checks that if we tap the latest tips `Supply`, and then a
 new tip is added, then we will also be told about this new tip.
 
 Now to make them pass! Here's the implementation in the `monitor`:
@@ -477,7 +477,7 @@ a `start` to dispatch the notifications asynchronously.
 The `latest-tips` method also needs a little care. Remember that anything we
 return from a `monitor` is not protected by the mutual exclusion. Thus, we
 should make a copy of the latest existing tips outside of the `supply` block,
-while the monitor is protected `%!tips-by-id`. Then, when the returned
+while the monitor is protecting `%!tips-by-id`. Then, when the returned
 `supply` block is tapped, we subscribe to the latest tips, and then emit each
 of the latest existing ones.
 
@@ -506,7 +506,7 @@ $ npm install --save-dev babel-loader babel-core babel-preset-es2015 babel-prese
 ```
 
 Next, we need to create a `.babelrc` file, saying to use this react preset
-(babel is the thing used to turn modern JavaScript into browser-compatible
+(Babel is the thing used to turn modern JavaScript into browser-compatible
 JavaScript). It should simply contain:
 
 ```
@@ -515,7 +515,7 @@ JavaScript). It should simply contain:
 }
 ```
 
-Finally, the `webpack.config.js` needs updating to say to use this. After the
+Finally, the `webpack.config.js` needs updates to use this. After the
 changes, it should look as follows:
 
 ```
@@ -891,7 +891,7 @@ asynchronous operation starts, which we can use to indicate that on the UI,
 and a further one once it has completed, so we can again indicate that the
 operation completed in the UI.
 
-First, let's setup `react-thunk`, which is a piece of middleware. Back in
+First, let's setup `redux-thunk`, which is a piece of middleware. Back in
 `frontend/index.js`, add:
 
 ```
@@ -916,7 +916,7 @@ Finally, change:
 let store = createStore(tipsyReducer);
 ```
 
-To apply the middlware also:
+To apply the middleware also:
 
 ```
 let store = createStore(tipsyReducer, applyMiddleware(thunkMiddleware));
@@ -937,7 +937,7 @@ Note that this doesn't yet change anything; build it and the behavior should
 be just the same. Now that we've done this, however, we can see that it will
 be possible to do this dispatch in a callback after the network operation.
 
-There's, of course, dozens of good ways to deal with asynchronous operations
+There's of course dozens of good ways to deal with asynchronous operations
 in JavaScript, and if you are seriously building single page applications I
 strongly recommend looking into using a promise library. There's also Redux
 middleware that will integrate with that. For now, we'll do the simplest
@@ -971,7 +971,7 @@ export function addTip() {
 ```
 
 Reload it, maybe open your browser's development tools (F12 usually), flip to
-the Network tap, and click Add Tip. All being well, you'll observe the request
+the Network tab, and click Add Tip. All being well, you'll observe the request
 was made and it produced a 204 response. Alternatively, you may like to stop
 the `cro run` and instead do `cro trace`; type a message, click Add Tip again,
 and you should see the request body dumped in the trace output.
@@ -1435,7 +1435,7 @@ refactor away in `frontend/index.js`:
 });
 ```
 
-Next, we'll update the dispatch to props map, to incldue our new agree and
+Next, we'll update the dispatch to props map, to include our new agree and
 disagree actions:
 
 ```
@@ -1491,7 +1491,7 @@ var App = props => (
 ```
 
 And there we have it. `npm run build`, refresh, and give it a spin. Clicking
-agree of disagree in either list ends up with the sort order in the Top Tips
+agree or disagree in either list ends up with the sort order in the Top Tips
 list changing to reflect the votes.
 
 At last, we're done.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -14,14 +14,14 @@ The following changes were made to the `Cro::Core` distribution:
   binary data
 * Provide a mode for machine-readable trace output
 * Always flush handle after producing trace output
-* Add a workaround for `CLOSE` phaser bug
+* Add a workaround for a `CLOSE` phaser bug
 
-The `Cro::SSL` distribution is decprecated in favor of `Cro::TLS`. In
+The `Cro::SSL` distribution is deprecated in favor of `Cro::TLS`. In
 `Cro::TLS`, the following changes were made:
 
 * Eliminate a workaround for an older `IO::Socket::Async::SSL` bug
 * The tests no longer assume the availability of an OpenSSL version with ALPN
-* Add a workaround for `CLOSE` phaser bug
+* Add a workaround for a `CLOSE` phaser bug
 
 Furthermore, the Cro team contributed bug fixes to `IO::Socket::Async::SSL`.
 
@@ -36,7 +36,7 @@ The following changes were made to the `Cro::HTTP` distribution:
     * Partial implementation of per-`route`-block middleware (`before` and
       `after`)
 * `Cro::HTTP::Client`
-    * Fix a HTTP/1.1 vs HTTP/2.0 detection bug
+    * Fix an HTTP/1.1 vs HTTP/2.0 detection bug
     * Remove unused attributes in HTTP client internals
     * Fix client to pass on the query string in the target URI
     * Implement `base-uri` constructor argument, which will be prepended to
@@ -51,9 +51,9 @@ The following changes were made to the `Cro::HTTP` distribution:
     * Fix a couple of occasional hangs in the HTTP/2.0 client
     * Implement window size handling in HTTP/2.0
 * General
-    * Correct mispelled body serializer class names
+    * Correct misspelled body serializer class names
     * Implement new `trace-output` API for better trace output
-    * Fix missing JSON::Fast dependency
+    * Fix missing `JSON::Fast` dependency
     * Use `Cro::TLS` instead of `Cro::SSL`
     * Make urlencoded and multipart bodies associative, so they can be
       hash-indexed


### PR DESCRIPTION
* Fix minor typos
* Fix missing/broken Markdown
* Use more idiomatic wording and punctuation