### PR TITLE
Refactor cro stub templates

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -24,6 +24,7 @@
                 "Cro::Tools::Services": "lib/Cro/Tools/Services.pm6",
                 "Cro::Tools::Template": "lib/Cro/Tools/Template.pm6",
                 "Cro::Tools::TemplateLocator": "lib/Cro/Tools/TemplateLocator.pm6",
+                "Cro::Tools::Template::Common": "lib/Cro/Tools/Template/Common.pm6",
                 "Cro::Tools::Template::HTTPService": "lib/Cro/Tools/Template/HTTPService.pm6",
                 "Cro::Tools::Template::ZeroMQWorkSinkService": "lib/Cro/Tools/Template/ZeroMQWorkSinkService.pm6",
                 "Cro::Tools::Template::ZeroMQWorkerService": "lib/Cro/Tools/Template/ZeroMQWorkerService.pm6",

--- a/lib/Cro/Tools/Template/Common.pm6
+++ b/lib/Cro/Tools/Template/Common.pm6
@@ -4,7 +4,11 @@ use META6;
 role Cro::Tools::Template::Common {
     method entrypoint-contents($id, %options, $links --> Str) { ... }
 
-    method meta6-object($name, %options --> META6) { ... }
+    method meta6-depends(%options) { ... }
+
+    method meta6-provides(%options) { ... }
+
+    method meta6-resources(%options) { ... }
 
     method cro-file-endpoints($id-uc, %options) { ... }
 
@@ -21,6 +25,26 @@ role Cro::Tools::Template::Common {
 
     method write-meta($file, $name, %options) {
         $file.spurt(self.meta6-object($name, %options).to-json);
+    }
+
+    method meta6-object($name, %options) {
+        my @depends = self.meta6-depends(%options);
+        my %provides = self.meta6-provides(%options);
+        my @resources = self.meta6-resources(%options);
+        my $m = META6.new(
+            :$name, :@depends, :%provides, :@resources,
+            description => 'Write me!',
+            version => Version.new('0.0.1'),
+            perl-version => Version.new('6.*'),
+            tags => (''),
+            authors => (''),
+            auth => 'Write me!',
+            source-url => 'Write me!',
+            support => META6::Support.new(
+                source => 'Write me!'
+            ),
+            license => 'Write me!'
+        );
     }
 
     method write-cro-file($file, $id, $name, %options, @links) {

--- a/lib/Cro/Tools/Template/Common.pm6
+++ b/lib/Cro/Tools/Template/Common.pm6
@@ -6,7 +6,7 @@ role Cro::Tools::Template::Common {
 
     method meta6-object($name, %options --> META6) { ... }
 
-    method cro-file-object($id, $name, %options, @links --> Cro::Tools::CroFile) { ... }
+    method cro-file-endpoints($id-uc, %options) { ... }
 
 
     method generate-common($where, $id, $name, %options, $generated-links, @links) {
@@ -25,6 +25,13 @@ role Cro::Tools::Template::Common {
 
     method write-cro-file($file, $id, $name, %options, @links) {
         $file.spurt(self.cro-file-object($id, $name, %options, @links).to-yaml);
+    }
+
+    method cro-file-object($id, $name, %options, @links) {
+        my $id-uc = self.env-name($id);
+        my @endpoints = self.cro-file-endpoints($id-uc, %options);
+        my $entrypoint = 'service.p6';
+        Cro::Tools::CroFile.new(:$id, :$name, :$entrypoint, :@endpoints, :@links)
     }
 
     method env-name($id) {

--- a/lib/Cro/Tools/Template/Common.pm6
+++ b/lib/Cro/Tools/Template/Common.pm6
@@ -4,27 +4,27 @@ use META6;
 role Cro::Tools::Template::Common {
     method entrypoint-contents($id, %options, $links --> Str) { ... }
 
-    method cro-file-object($id, $name, %options, @links --> Cro::Tools::CroFile) { ... }
-
     method meta6-object($name, %options --> META6) { ... }
+
+    method cro-file-object($id, $name, %options, @links --> Cro::Tools::CroFile) { ... }
 
 
     method generate-common($where, $id, $name, %options, $generated-links, @links) {
         self.write-entrypoint($where.add('service.p6'), $id, %options, $generated-links);
-        self.write-cro-file($where.add('.cro.yml'), $id, $name, %options, @links);
         self.write-meta($where.add('META6.json'), $name, %options);
+        self.write-cro-file($where.add('.cro.yml'), $id, $name, %options, @links);
     }
 
     method write-entrypoint($file, $id, %options, $links) {
         $file.spurt(self.entrypoint-contents($id, %options, $links));
     }
 
-    method write-cro-file($file, $id, $name, %options, @links) {
-        $file.spurt(self.cro-file-object($id, $name, %options, @links).to-yaml);
-    }
-
     method write-meta($file, $name, %options) {
         $file.spurt(self.meta6-object($name, %options).to-json);
+    }
+
+    method write-cro-file($file, $id, $name, %options, @links) {
+        $file.spurt(self.cro-file-object($id, $name, %options, @links).to-yaml);
     }
 
     method env-name($id) {

--- a/lib/Cro/Tools/Template/Common.pm6
+++ b/lib/Cro/Tools/Template/Common.pm6
@@ -6,9 +6,9 @@ role Cro::Tools::Template::Common {
 
     method meta6-depends(%options) { ... }
 
-    method meta6-provides(%options) { ... }
+    method meta6-provides(%options) { () }
 
-    method meta6-resources(%options) { ... }
+    method meta6-resources(%options) { () }
 
     method cro-file-endpoints($id-uc, %options) { ... }
 

--- a/lib/Cro/Tools/Template/Common.pm6
+++ b/lib/Cro/Tools/Template/Common.pm6
@@ -1,0 +1,29 @@
+use Cro::Tools::CroFile;
+use META6;
+
+role Cro::Tools::Template::Common {
+    method entrypoint-contents($id, %options, $links --> Str) { ... }
+
+    method cro-file-object($id, $name, %options, @links --> Cro::Tools::CroFile) { ... }
+
+    method meta6-object($name, %options --> META6) { ... }
+
+
+    method generate-common($where, $id, $name, %options, $generated-links, @links) {
+        self.write-entrypoint($where.add('service.p6'), $id, %options, $generated-links);
+        self.write-cro-file($where.add('.cro.yml'), $id, $name, %options, @links);
+        self.write-meta($where.add('META6.json'), $name, %options);
+    }
+
+    method write-entrypoint($file, $id, %options, $links) {
+        $file.spurt(self.entrypoint-contents($id, %options, $links));
+    }
+
+    method write-cro-file($file, $id, $name, %options, @links) {
+        $file.spurt(self.cro-file-object($id, $name, %options, @links).to-yaml);
+    }
+
+    method write-meta($file, $name, %options) {
+        $file.spurt(self.meta6-object($name, %options).to-json);
+    }
+}

--- a/lib/Cro/Tools/Template/Common.pm6
+++ b/lib/Cro/Tools/Template/Common.pm6
@@ -26,4 +26,8 @@ role Cro::Tools::Template::Common {
     method write-meta($file, $name, %options) {
         $file.spurt(self.meta6-object($name, %options).to-json);
     }
+
+    method env-name($id) {
+        $id.uc.subst(/<-[A..Za..z_]>/, '_', :g)
+    }
 }

--- a/lib/Cro/Tools/Template/HTTPService.pm6
+++ b/lib/Cro/Tools/Template/HTTPService.pm6
@@ -1,8 +1,9 @@
 use Cro::Tools::CroFile;
 use Cro::Tools::Template;
+use Cro::Tools::Template::Common;
 use META6;
 
-class Cro::Tools::Template::HTTPService does Cro::Tools::Template {
+class Cro::Tools::Template::HTTPService does Cro::Tools::Template does Cro::Tools::Template::Common {
     method id(--> Str) { 'http' }
 
     method name(--> Str) { 'HTTP Service' }
@@ -51,9 +52,7 @@ class Cro::Tools::Template::HTTPService does Cro::Tools::Template {
         mkdir $lib;
         self.write-fake-tls($where) if %options<secure>;
         self.write-app-module($lib.add('Routes.pm6'), $name, %options<websocket>, $generated-links);
-        self.write-entrypoint($where.add('service.p6'), $id, %options, $generated-links);
-        self.write-cro-file($where.add('.cro.yml'), $id, $name, %options, @links);
-        self.write-meta($where.add('META6.json'), $name, %options);
+        self.generate-common($where, $id, $name, %options, $generated-links, @links);
     }
 
     method write-fake-tls($where) {
@@ -173,10 +172,6 @@ class Cro::Tools::Template::HTTPService does Cro::Tools::Template {
         $entrypoint
     }
 
-    method write-entrypoint($file, $id, %options, $links) {
-        $file.spurt(self.entrypoint-contents($id, %options, $links));
-    }
-
     method cro-file-object($id, $name, %options, @links) {
         my $id-uc = env-name($id);
         my $cro-file = Cro::Tools::CroFile.new(
@@ -190,10 +185,6 @@ class Cro::Tools::Template::HTTPService does Cro::Tools::Template {
                 )
             ], :@links
         );
-    }
-
-    method write-cro-file($file, $id, $name, %options, @links) {
-        $file.spurt(self.cro-file-object($id, $name, %options, @links).to-yaml);
     }
 
     method meta6-object($name, %options) {
@@ -220,10 +211,6 @@ class Cro::Tools::Template::HTTPService does Cro::Tools::Template {
                                               fake-tls/server-key.pem> !! (),
             license => 'Write me!'
         );
-    }
-
-    method write-meta($file, $name, %options) {
-        $file.spurt(self.meta6-object($name, %options).to-json);
     }
 
     sub env-name($id) {

--- a/lib/Cro/Tools/Template/HTTPService.pm6
+++ b/lib/Cro/Tools/Template/HTTPService.pm6
@@ -1,7 +1,6 @@
 use Cro::Tools::CroFile;
 use Cro::Tools::Template;
 use Cro::Tools::Template::Common;
-use META6;
 
 class Cro::Tools::Template::HTTPService does Cro::Tools::Template does Cro::Tools::Template::Common {
     method id(--> Str) { 'http' }

--- a/lib/Cro/Tools/Template/HTTPService.pm6
+++ b/lib/Cro/Tools/Template/HTTPService.pm6
@@ -107,7 +107,7 @@ class Cro::Tools::Template::HTTPService does Cro::Tools::Template does Cro::Tool
     }
 
     method entrypoint-contents($id, %options, $links) {
-        my $env-name = env-name($id);
+        my $env-name = self.env-name($id);
         my $http = %options<http1> && %options<http2>
             ?? <1.1 2>
             !! %options<http1> ?? <1.1> !! <2>;
@@ -173,7 +173,7 @@ class Cro::Tools::Template::HTTPService does Cro::Tools::Template does Cro::Tool
     }
 
     method cro-file-object($id, $name, %options, @links) {
-        my $id-uc = env-name($id);
+        my $id-uc = self.env-name($id);
         my $cro-file = Cro::Tools::CroFile.new(
             :$id, :$name, :entrypoint<service.p6>, :endpoints[
                 Cro::Tools::CroFile::Endpoint.new(
@@ -211,9 +211,5 @@ class Cro::Tools::Template::HTTPService does Cro::Tools::Template does Cro::Tool
                                               fake-tls/server-key.pem> !! (),
             license => 'Write me!'
         );
-    }
-
-    sub env-name($id) {
-        $id.uc.subst(/<-[A..Za..z_]>/, '_', :g)
     }
 }

--- a/lib/Cro/Tools/Template/HTTPService.pm6
+++ b/lib/Cro/Tools/Template/HTTPService.pm6
@@ -172,19 +172,14 @@ class Cro::Tools::Template::HTTPService does Cro::Tools::Template does Cro::Tool
         $entrypoint
     }
 
-    method cro-file-object($id, $name, %options, @links) {
-        my $id-uc = self.env-name($id);
-        my $cro-file = Cro::Tools::CroFile.new(
-            :$id, :$name, :entrypoint<service.p6>, :endpoints[
-                Cro::Tools::CroFile::Endpoint.new(
-                    id => %options<secure> ?? 'https' !! <http>,
-                    name => %options<secure> ?? 'HTTPS' !! 'HTTP',
-                    protocol => %options<secure> ?? 'https' !! 'http',
-                    host-env => $id-uc ~ '_HOST',
-                    port-env => $id-uc ~ '_PORT'
-                )
-            ], :@links
-        );
+    method cro-file-endpoints($id-uc, %options) {
+        Cro::Tools::CroFile::Endpoint.new(
+            id => %options<secure> ?? 'https' !! <http>,
+            name => %options<secure> ?? 'HTTPS' !! 'HTTP',
+            protocol => %options<secure> ?? 'https' !! 'http',
+            host-env => $id-uc ~ '_HOST',
+            port-env => $id-uc ~ '_PORT'
+        ),
     }
 
     method meta6-object($name, %options) {

--- a/lib/Cro/Tools/Template/HTTPService.pm6
+++ b/lib/Cro/Tools/Template/HTTPService.pm6
@@ -182,29 +182,18 @@ class Cro::Tools::Template::HTTPService does Cro::Tools::Template does Cro::Tool
         ),
     }
 
-    method meta6-object($name, %options) {
-        my @deps = <Cro::HTTP>;
-        @deps.push: <Cro::WebSocket> if %options<websocket>;
-        my $m = META6.new(
-            name => $name,
-            description => 'Write me!',
-            version => Version.new('0.0.1'),
-            perl-version => Version.new('6.*'),
-            depends => @deps,
-            tags => (''),
-            authors => (''),
-            auth => 'Write me!',
-            source-url => 'Write me!',
-            support => META6::Support.new(
-                source => 'Write me!'
-            ),
-            provides => {
-                'Routes.pm6' => 'lib/Routes.pm6'
-            },
-            resources => %options<secure> ?? <fake-tls/ca-crt.pem
-                                              fake-tls/server-crt.pem
-                                              fake-tls/server-key.pem> !! (),
-            license => 'Write me!'
-        );
+    method meta6-depends(%options) {
+         <Cro::HTTP>,
+        (<Cro::WebSocket> if %options<websocket>)
+    }
+
+    method meta6-resources(%options) {
+        %options<secure> ?? <fake-tls/ca-crt.pem
+                             fake-tls/server-crt.pem
+                             fake-tls/server-key.pem> !! ()
+    }
+
+    method meta6-provides(%options) {
+        'Routes.pm6' => 'lib/Routes.pm6',
     }
 }

--- a/lib/Cro/Tools/Template/HTTPService.pm6
+++ b/lib/Cro/Tools/Template/HTTPService.pm6
@@ -45,17 +45,6 @@ class Cro::Tools::Template::HTTPService does Cro::Tools::Template {
         return @errors;
     }
 
-    method write-fake-tls($where) {
-        my $res = $where.add('RESOURCES/');
-        mkdir $res;
-        mkdir $res.add('fake-tls');
-        for <fake-tls/ca-crt.pem fake-tls/server-crt.pem fake-tls/server-key.pem> -> $fn {
-            with %?RESOURCES{$fn} {
-                copy($_, $res.add($fn));
-            }
-        }
-    }
-
     method generate(IO::Path $where, Str $id, Str $name,
                     %options, $generated-links, @links) {
         my $lib = $where.add('lib');
@@ -65,6 +54,17 @@ class Cro::Tools::Template::HTTPService does Cro::Tools::Template {
         self.write-entrypoint($where.add('service.p6'), $id, %options, $generated-links);
         self.write-cro-file($where.add('.cro.yml'), $id, $name, %options, @links);
         self.write-meta($where.add('META6.json'), $name, %options);
+    }
+
+    method write-fake-tls($where) {
+        my $res = $where.add('RESOURCES/');
+        mkdir $res;
+        mkdir $res.add('fake-tls');
+        for <fake-tls/ca-crt.pem fake-tls/server-crt.pem fake-tls/server-key.pem> -> $fn {
+            with %?RESOURCES{$fn} {
+                copy($_, $res.add($fn));
+            }
+        }
     }
 
     method app-module-contents($name, $include-websocket, $links) {

--- a/lib/Cro/Tools/Template/ZeroMQWorkSinkService.pm6
+++ b/lib/Cro/Tools/Template/ZeroMQWorkSinkService.pm6
@@ -1,8 +1,9 @@
 use Cro::Tools::CroFile;
 use Cro::Tools::Template;
+use Cro::Tools::Template::Common;
 use META6;
 
-class Cro::Tools::Template::ZeroMQWorkSinkService does Cro::Tools::Template {
+class Cro::Tools::Template::ZeroMQWorkSinkService does Cro::Tools::Template does Cro::Tools::Template::Common {
     method id(--> Str) { 'zeromq-worksink' }
 
     method name(--> Str) { 'ZeroMQ Work Sink Service' }
@@ -13,13 +14,11 @@ class Cro::Tools::Template::ZeroMQWorkSinkService does Cro::Tools::Template {
 
     method generate(IO::Path $where, Str $id, Str $name,
                     %options, $generated-links, @links) {
-        write-entrypoint($where.add('service.p6'), $id, %options);
-        write-cro-file($where.add('.cro.yml'), $id, $name, %options, @links);
-        write-meta($where.add('META6.json'), $name);
+        self.generate-common($where, $id, $name, %options, $generated-links, @links);
     }
 
-    sub write-entrypoint($file, $id, %options) {
-        my $env-name = env-name($id);
+    method entrypoint-contents($id, %options, $links) {
+        my $env-name = self.env-name($id);
         my $entrypoint = q:to/CODE/;
         use Cro::ZeroMQ::Collector;
 
@@ -41,47 +40,21 @@ class Cro::Tools::Template::ZeroMQWorkSinkService does Cro::Tools::Template {
             }
         }
         CODE
-
-        $file.spurt($entrypoint);
     }
 
-    sub write-cro-file($file, $id, $name, %options, @links) {
-        my $id-uc = env-name($id);
-        my $cro-file = Cro::Tools::CroFile.new(
-            :$id, :$name, :entrypoint<service.p6>, :entrypoints[
-                Cro::Tools::CroFile::Endpoint.new(
-                    id => 'zmq',
-                    name => 'ZeroMQ',
-                    protocol => 'tcp',
-                    host-env => $id-uc ~ '_HOST',
-                    port-env => $id-uc ~ '_PORT'
-                )
-            ], :@links
-        );
-        $file.spurt($cro-file.to-yaml());
+    method cro-file-endpoints($id-uc, %options) {
+        Cro::Tools::CroFile::Endpoint.new(
+            id => 'zmq',
+            name => 'ZeroMQ',
+            protocol => 'tcp',
+            host-env => $id-uc ~ '_HOST',
+            port-env => $id-uc ~ '_PORT'
+        ),
     }
 
-    sub write-meta($file, $name) {
-        my $m = META6.new(
-            name => $name,
-            description => 'Write me!',
-            version => Version.new('0.0.1'),
-            perl-version => Version.new('6.*'),
-            depends => <Cro::ZMQ>,
-            tags => (''),
-            authors => (''),
-            auth => 'Write me!',
-            source-url => 'Write me!',
-            support => META6::Support.new(
-                source => 'Write me!'
-            ),
-            provides => {},
-            license => 'Write me!'
-        );
-        spurt($file, $m.to-json);
-    }
+    method meta6-depends(%options) { <Cro::ZMQ> }
 
-    sub env-name($id) {
-        $id.uc.subst(/<-[A..Za..z_]>/, '_', :g)
-    }
+    method meta6-provides(%options) { () }
+
+    method meta6-resources(%options) { () }
 }

--- a/lib/Cro/Tools/Template/ZeroMQWorkSinkService.pm6
+++ b/lib/Cro/Tools/Template/ZeroMQWorkSinkService.pm6
@@ -19,15 +19,18 @@ class Cro::Tools::Template::ZeroMQWorkSinkService does Cro::Tools::Template does
 
     method entrypoint-contents($id, %options, $links) {
         my $env-name = self.env-name($id);
-        my $entrypoint = q:to/CODE/;
+        my $service = 'MY_TEST_ZMQ_SERVICE';
+        my $entrypoint = q:c:to/CODE/;
         use Cro::ZeroMQ::Collector;
 
-        my $worker = Cro::ZeroMQ::Collector.pull(
-            connect => "tcp://%*ENV<MY_TEST_ZMQ_SERVICE_HOST>:%*ENV<MY_TEST_ZMQ_SERVICE_PORT>");
-
+        my $connect = "tcp://%*ENV<{$service}_HOST>:%*ENV<{$service}_PORT>";
+        my $worker = Cro::ZeroMQ::Collector.pull(:$connect);
         my $work = $worker.Supply.share;
 
-        say "Listening at tcp://%*ENV<MY_TEST_ZMQ_SERVICE_HOST>:%*ENV<MY_TEST_ZMQ_SERVICE_PORT>";
+        say "Pulling from $connect";
+        CODE
+
+        $entrypoint ~= q:to/CODE/;
         react {
             whenever $work {
                 say $work.perl;

--- a/lib/Cro/Tools/Template/ZeroMQWorkSinkService.pm6
+++ b/lib/Cro/Tools/Template/ZeroMQWorkSinkService.pm6
@@ -56,8 +56,4 @@ class Cro::Tools::Template::ZeroMQWorkSinkService does Cro::Tools::Template does
     }
 
     method meta6-depends(%options) { <Cro::ZMQ> }
-
-    method meta6-provides(%options) { () }
-
-    method meta6-resources(%options) { () }
 }

--- a/lib/Cro/Tools/Template/ZeroMQWorkSinkService.pm6
+++ b/lib/Cro/Tools/Template/ZeroMQWorkSinkService.pm6
@@ -1,7 +1,6 @@
 use Cro::Tools::CroFile;
 use Cro::Tools::Template;
 use Cro::Tools::Template::Common;
-use META6;
 
 class Cro::Tools::Template::ZeroMQWorkSinkService does Cro::Tools::Template does Cro::Tools::Template::Common {
     method id(--> Str) { 'zeromq-worksink' }

--- a/lib/Cro/Tools/Template/ZeroMQWorkerService.pm6
+++ b/lib/Cro/Tools/Template/ZeroMQWorkerService.pm6
@@ -1,8 +1,9 @@
 use Cro::Tools::CroFile;
 use Cro::Tools::Template;
+use Cro::Tools::Template::Common;
 use META6;
 
-class Cro::Tools::Template::ZeroMQWorkerService does Cro::Tools::Template {
+class Cro::Tools::Template::ZeroMQWorkerService does Cro::Tools::Template does Cro::Tools::Template::Common {
     method id(--> Str) { 'zeromq-worker' }
 
     method name(--> Str) { 'ZeroMQ Worker Service' }
@@ -13,13 +14,11 @@ class Cro::Tools::Template::ZeroMQWorkerService does Cro::Tools::Template {
 
     method generate(IO::Path $where, Str $id, Str $name, %options, $generated-links, @links) {
         die "Horrible death";
-        write-entrypoint($where.add('service.p6'), $id, %options);
-        write-cro-file($where.add('.cro.yml'), $id, $name, %options, @links);
-        write-meta($where.add('META6.json'), $name);
+        self.generate-common($where, $id, $name, %options, $generated-links, @links);
     }
 
-    sub write-entrypoint($file, $id, %options) {
-        my $env-name = env-name($id);
+    method entrypoint-contents($id, %options, $links) {
+        my $env-name = self.env-name($id);
         my $entrypoint = q:to/CODE/;
         use Cro;
         use Cro::ZeroMQ::Service;
@@ -53,47 +52,21 @@ class Cro::Tools::Template::ZeroMQWorkerService does Cro::Tools::Template {
             }
         }
         CODE
-
-        $file.spurt($entrypoint);
     }
 
-    sub write-cro-file($file, $id, $name, %options, @links) {
-        my $id-uc = env-name($id);
-        my $cro-file = Cro::Tools::CroFile.new(
-            :$id, :$name, :entrypoint<service.p6>, :entrypoints[
-                Cro::Tools::CroFile::Endpoint.new(
-                    id => 'zmq',
-                    name => 'ZeroMQ',
-                    protocol => 'tcp',
-                    host-env => $id-uc ~ '_HOST',
-                    port-env => $id-uc ~ '_PORT'
-                )
-            ], :@links
-        );
-        $file.spurt($cro-file.to-yaml());
+    method cro-file-endpoints($id-uc, %options) {
+        Cro::Tools::CroFile::Endpoint.new(
+            id => 'zmq',
+            name => 'ZeroMQ',
+            protocol => 'tcp',
+            host-env => $id-uc ~ '_HOST',
+            port-env => $id-uc ~ '_PORT'
+        ),
     }
 
-    sub write-meta($file, $name) {
-        my $m = META6.new(
-            name => $name,
-            description => 'Write me!',
-            version => Version.new('0.0.1'),
-            perl-version => Version.new('6.*'),
-            depends => <Cro::ZMQ>,
-            tags => (''),
-            authors => (''),
-            auth => 'Write me!',
-            source-url => 'Write me!',
-            support => META6::Support.new(
-                source => 'Write me!'
-            ),
-            provides => {},
-            license => 'Write me!'
-        );
-        spurt($file, $m.to-json);
-    }
+    method meta6-depends(%options) { <Cro::ZMQ> }
 
-    sub env-name($id) {
-        $id.uc.subst(/<-[A..Za..z_]>/, '_', :g)
-    }
+    method meta6-provides(%options) { () }
+
+    method meta6-resources(%options) { () }
 }

--- a/lib/Cro/Tools/Template/ZeroMQWorkerService.pm6
+++ b/lib/Cro/Tools/Template/ZeroMQWorkerService.pm6
@@ -13,7 +13,6 @@ class Cro::Tools::Template::ZeroMQWorkerService does Cro::Tools::Template does C
     method get-option-errors($options --> List) { () }
 
     method generate(IO::Path $where, Str $id, Str $name, %options, $generated-links, @links) {
-        die "Horrible death";
         self.generate-common($where, $id, $name, %options, $generated-links, @links);
     }
 

--- a/lib/Cro/Tools/Template/ZeroMQWorkerService.pm6
+++ b/lib/Cro/Tools/Template/ZeroMQWorkerService.pm6
@@ -1,7 +1,6 @@
 use Cro::Tools::CroFile;
 use Cro::Tools::Template;
 use Cro::Tools::Template::Common;
-use META6;
 
 class Cro::Tools::Template::ZeroMQWorkerService does Cro::Tools::Template does Cro::Tools::Template::Common {
     method id(--> Str) { 'zeromq-worker' }

--- a/lib/Cro/Tools/Template/ZeroMQWorkerService.pm6
+++ b/lib/Cro/Tools/Template/ZeroMQWorkerService.pm6
@@ -72,8 +72,4 @@ class Cro::Tools::Template::ZeroMQWorkerService does Cro::Tools::Template does C
     }
 
     method meta6-depends(%options) { <Cro::ZMQ> }
-
-    method meta6-provides(%options) { () }
-
-    method meta6-resources(%options) { () }
 }


### PR DESCRIPTION
This is the first phase of my proposed changes to the `cro stub` templates.  It mostly consists of:

- Separating content-generation routines from file-writing routines, to aid testing and subclassing
- Factoring out common implementation into a new `Cro::Tools::Template::Common` role
- Fixing bugs noticed while factoring out common bits
- Minor cleanups (mostly DRY violations)

If this is accepted, my plan for the next phase is to actually do a subclass of an existing template, and fix any remaining subclassing difficulties encountered in doing so.

This PR doesn't contain additional automated tests.  I did check after each commit that generated stubs remained identical (or only contained the changes expected from bug fixes).
