### PR TITLE
Tweak link in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -86,7 +86,7 @@ Pipeline components:
 
 ### Cro::WebApp
 
-* [Cro::WebApp::Template](docs/reference/cro-webapp-template.md)
+* [Cro::WebApp::Template](docs/reference/cro-webapp-template)
 
 ### Cro::OpenAPI::RoutesFromDefinition
 


### PR DESCRIPTION
Hello 

I was looking at the page being rendered in a web browser, but moved to a non-existent URL.
https://cro.services/docs#Cro::WebApp

This problem because that  `.md` was attached at the end.
So, I fixed it.

Thanks!