### PR TITLE
documentation: Perl 6 -> Raku

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -2,7 +2,7 @@
     "perl"          : "6.*",
     "name"          : "cro",
     "version"       : "0.8.3",
-    "description"   : "Libraries and tools for building reactive services in Perl 6. This installs the cro command line and web tool, along with HTTP (including HTTPS and HTTP/2.0) and WebSocket support.",
+    "description"   : "Libraries and tools for building reactive services in Raku. This installs the cro command line and web tool, along with HTTP (including HTTPS and HTTP/2.0) and WebSocket support.",
     "tags"          : [ "HTTP", "WebSocket" ],
     "authors"       : [ "Jonathan Worthington <jnthn@jnthn.net>" ],
     "license"       : "Artistic-2.0",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Cro [![Build Status](https://travis-ci.org/croservices/cro.svg?branch=master)](https://travis-ci.org/croservices/cro)
 
 This is part of the Cro libraries for implementing services and distributed
-systems in Perl 6. See the [Cro website](https://cro.services/) for further
+systems in Raku. See the [Cro website](https://cro.services/) for further
 information and documentation.

--- a/docs/approach.md
+++ b/docs/approach.md
@@ -1,6 +1,6 @@
 # The Cro approach
 
-At its heart, Cro is all about building up chains of Perl 6 supplies that
+At its heart, Cro is all about building up chains of Raku supplies that
 process messages that arrive from the network and produce messages to be sent
 over the network.
 
@@ -185,11 +185,11 @@ my Cro::Connector $conn = Cro.compose(
 
 my $req = supply {
     my Cro::HTTP::Request $req .= new(:method<GET>, :target</>);
-    $req.add-header('Host', 'www.perl6.org');
+    $req.add-header('Host', 'www.raku.org');
     emit $req;
 }
 react {
-    whenever $conn.establish($req, :host<www.perl6.org>, :port(80)) {
+    whenever $conn.establish($req, :host<www.raku.org>, :port(80)) {
         say ~$response; # Dump headers
     }
 }

--- a/docs/cro-tool.md
+++ b/docs/cro-tool.md
@@ -24,7 +24,7 @@ Where
   to the stub, together with options specific to the service type
 
 If the links and options are not specified, then they will be requested
-interactively. To provide the options, place them in quotes using Perl 6
+interactively. To provide the options, place them in quotes using Raku
 colonpair-like syntax, where `:foo` enables an option, `:!foo` disables an
 option, and `:foo<bar>` is the option `foo` with the value `bar`. For example:
 

--- a/docs/cro-yml.md
+++ b/docs/cro-yml.md
@@ -22,7 +22,7 @@ The `.cro.yml` file should be a dictionary at the top level. It must include:
   letters A..Z and a..z, the digits 0..9, the underscore (`_`), the dash (`-`)
   and the forward slash ('/'). This will be used to identify the service when
   using the CLI (such as in `cro run service-id`).
-* The key `entrypoint`, which is the Perl 6 source file that should be run to
+* The key `entrypoint`, which is the Raku source file that should be run to
   start the service. It should be specified relative to the `.cro.yml` file.
   This will be used by the `cro` development tool to start the service.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ as well as covering some more advanced topics:
 ## Getting Help
 
 * Post your question on [Stack Overflow](https://stackoverflow.com/) (be sure
-  to tag it `perl6` and `cro`)
+  to tag it `perl6`, `raku` and `cro`)
 * Visit the `#cro` IRC channel on freenode
 * Get [commercial support and training](/training-support)
 

--- a/docs/intro/getstarted.md
+++ b/docs/intro/getstarted.md
@@ -2,13 +2,13 @@
 
 Here's a list of things to do to get Cro running on your machine.
 
-## Install Perl 6
+## Install Raku
 
-Cro services are written in Perl 6; if you have not yet installed that,
-[see these instructions](https://perl6.org/downloads/). Note that you will
-need a fairly modern Perl 6; the ones included in packages can be very old.
+Cro services are written in Raku; if you have not yet installed that,
+[see these instructions](https://raku.org/downloads/). Note that you will
+need a fairly modern Raku; the ones included in packages can be very old.
 
-Provided you install Perl 6 using Rakudo Star, the `zef` module manager will
+Provided you install Raku using Rakudo Star, the `zef` module manager will
 also be installed.
 
 ## Install Cro
@@ -52,7 +52,7 @@ react whenever signal(SIGINT) {
 To start the service, just run the script from the command line:
 
 ```
-perl6 hello.p6
+raku hello.p6
 ```
 
 ## Check that the service runs ok

--- a/docs/intro/http-client.md
+++ b/docs/intro/http-client.md
@@ -10,7 +10,7 @@ The simplest `GET` request can be written as:
 use Cro::HTTP::Client;
 
 # Make the request
-my $resp = await Cro::HTTP::Client.get('https://www.perl6.org/');
+my $resp = await Cro::HTTP::Client.get('https://www.raku.org/');
 ```
 
 Different methods represent different HTTP methods, such as `get`,
@@ -33,7 +33,7 @@ my $client = Cro::HTTP::Client.new(
     headers => [
         User-agent => 'Cro'
     ]);
-my $resp = await $client.get('https://www.perl6.org/');
+my $resp = await $client.get('https://www.raku.org/');
 ```
 
 Making an instance has the advantage that connections will be re-used between

--- a/docs/intro/spa-with-cro.md
+++ b/docs/intro/spa-with-cro.md
@@ -70,7 +70,7 @@ $ curl http://localhost:20000
 ```
 
 I like to regularly commit as I work. So, I'll create a git repository, add
-a `.gitignore` file (to ignore Perl 6 precompilation output), and commit the
+a `.gitignore` file (to ignore Raku precompilation output), and commit the
 stub.
 
 ```
@@ -667,7 +667,7 @@ as network I/O). They are pure calculation. Our state will, for now, be very
 simple: just the content of the text box.
 
 Writing reducers is much more convenient when we have the upcoming spread
-operator in JavaScript; it's a prefix `...`, and works much like Perl 6's
+operator in JavaScript; it's a prefix `...`, and works much like Raku's
 prefix `|` operator for flattening. Since we already have a build toolchain,
 we can add it by installing another syntax transform:
 
@@ -1506,7 +1506,7 @@ $ git commit -m "Add agree/disagree feature" .
 
 In this tutorial we've gone from zero to reactive single page application. The
 frontend is written in modern ES6 using React and Redux. The backend is in
-Perl 6, using Cro. They communicate using both HTTP and web sockets. And both
+Raku, using Cro. They communicate using both HTTP and web sockets. And both
 declare their dependencies, so getting started for a new developer is just a
 case of:
 

--- a/docs/reference/cro-http-client.md
+++ b/docs/reference/cro-http-client.md
@@ -29,7 +29,7 @@ the type object or an instance of `Cro::HTTP::Client`. They will all return a
 `Promise`, which will be kept if the request is successful or broken if an
 error occurs.
 
-    my $resp = await Cro::HTTP::Client.get('https://www.perl6.org/');
+    my $resp = await Cro::HTTP::Client.get('https://www.raku.org/');
 
 The response will be provided as a `Cro::HTTP::Response` object. It will be
 produced as soon as the request headers are available; the body may not yet

--- a/docs/reference/cro-http-cookie.md
+++ b/docs/reference/cro-http-cookie.md
@@ -15,9 +15,9 @@ modified version of an existing instance, passed to `clone`.
   allowed in `cookie-name` per RFC 6265 (required)
 * `value` - the cookie value; constrained to only contain the characters
   in the range specified in `cookie-octet` in RFC 6265 (required)
-* `expires` - the expiration time of the cookie, specified as a Perl 6
+* `expires` - the expiration time of the cookie, specified as a Raku
   `DateTime`
-* `max-age` - the maximum age of the cookie in seconds, specified as a Perl 6
+* `max-age` - the maximum age of the cookie in seconds, specified as a Raku
   `Duration` (in the constructor any `Real` may be passed; fractional parts
   will be rounded)
 * `domain` - the domain the cookie is restricted to, if any; specified as a

--- a/docs/reference/cro-http-pushpromise.md
+++ b/docs/reference/cro-http-pushpromise.md
@@ -9,7 +9,7 @@ push promise.
 
 ## Getting the promised response
 
-The `response` method returns a Perl 6 `Promise` that will be `Kept` with a
+The `response` method returns a Raku `Promise` that will be `Kept` with a
 `Cro::HTTP::Response` object when the promised response is delivered. Should
 that not be possible for some reason, then the `Promise` will be broken.
 

--- a/docs/reference/cro-http-router.md
+++ b/docs/reference/cro-http-router.md
@@ -7,7 +7,7 @@ in turn produce responses.
 
 ## URI segment matching
 
-The router uses Perl 6 signatures to match URLs and extract segments from them.
+The router uses Raku signatures to match URLs and extract segments from them.
 A set of routes are placed in a `route` block. The empty signature corresponds
 to `/`.
 
@@ -197,7 +197,7 @@ the result will be a HTTP 405 Method Not Allowed response.
 Named parameters in a route signature can be used to unpack and constrain the
 route match on additional aspects of the request. By default, values are taken
 from the query string, however traits can be applied to have them use data
-from other sources. Note that named parameters in Perl 6 are optional by default;
+from other sources. Note that named parameters in Raku are optional by default;
 if the query string parameter is required, then it should be marked as such.
 
 ```
@@ -382,7 +382,7 @@ put -> 'product', $id, 'image', $filename {
 }
 ```
 
-The block signature may use Perl 6 signatures in order to unpack the data that
+The block signature may use Raku signatures in order to unpack the data that
 was submitted. This is useful to, for example, unpack a JSON object:
 
 ```
@@ -604,7 +604,7 @@ arguments on to `content` after setting the status code. They are:
 * `forbidden`, for HTTP 403 Forbidden
 * `conflict`, for HTTP 409 Conflict
 
-If the request handler evaluates to `...` (that is, the Perl 6 syntax for stub
+If the request handler evaluates to `...` (that is, the Raku syntax for stub
 code), then a HTTP 510 Not Implemented response will be produced. If evaluating
 the route handler produces an exception, then the exception will be passed on.
 It will then typically be handled by the response serializer, which will produce

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -103,7 +103,7 @@ The following changes were made to the `Cro::WebApp` distribution:
 
 * Implement template conditionals directly using variables, like
   `<?$foo>...</?>` and `<!$foo>...</!>`
-* Support all of the Perl 6 string comparison operators
+* Support all of the Raku string comparison operators
 * Add documentation comments to various types and routines
 
 The following changes were made to the `Cro` distribution:
@@ -251,7 +251,7 @@ The following changes were made to the `Cro::HTTP` distribution:
   `Cro::HTTP::Auth::WebToken::Bearer`.
 * Fix compliance with the HTTP spec on the host header: now we append
   `Host` header when non-standard HTTP port (not 80 nor 443) is used.
-* Force use of Perl 6.d semantics in the HTTP client, which avoids
+* Force use of Raku.d semantics in the HTTP client, which avoids
   various ways that it might end up working slowly due to eating too
   many real threads.
 * When a route fails to match with 400 or 401, and another route fails
@@ -363,7 +363,7 @@ This release brings two major new features:
   services specified using an [OpenAPI v3](https://github.com/OAI/OpenAPI-Specification)
   document without needing to repeat the routes, validation, and so forth
   from the document. This work was funded by [Nick Logan (ugexe)](https://deathbyperl6.com/).
-  Three modules for wider Perl 6 use were produced and released as part of
+  Three modules for wider Raku use were produced and released as part of
   this work: `JSON::Pointer`, `OpenAPI::Model`, and `OpenAPI::Schema::Validate`.
 * The `Cro::HTTP::Test` module, which offers a convenient way to write tests
   for HTTP services. It is, of course, primarily aimed at those services built


### PR DESCRIPTION
* when save, replace "Perl 6" by Raku both in documentation and description
* replace perl6.org by raku.org