### PR TITLE
Handle IPv6 literals in URL format to "cro web"

### DIFF
--- a/lib/Cro/Tools/CLI.pm6
+++ b/lib/Cro/Tools/CLI.pm6
@@ -17,6 +17,7 @@ multi MAIN('web', Str $host-port = '10203',
         :$filter, :$trace, :@trace-filters
     );
     my $service = web $host, $port, $runner;
+    $host = "[" ~ $host ~ "]" if $host.contains(":"); # Handle IPv6 literals
     say "Cro web interface running at http://$host:$port/";
     stop-on-sigint($service);
 }
@@ -324,10 +325,17 @@ sub parse-host-port($host-port) {
     my ($host, $port);
     given $host-port {
         when /^(\d+)$/ {
+            # Just a port number
             $host = 'localhost';
             $port = +$host-port;
         }
+        when /^ '[' (.+) ']:' (\d+) $/ {
+            # IPv6 literal in URL format with port
+            $host = ~$0;
+            $port = +$1;
+        }
         when /^ (.+) ':' (\d+) $/ {
+            # Hostname followed by port
             $host = ~$0;
             $port = +$1;
         }


### PR DESCRIPTION
This allows you to do things like "cro web [::]:12345" or "cro web [2001:db8::1]::12345" which makes it more clear where the IPv6 address begins and ends.  The old host-port formats continue to work.