### PR TITLE
Allow specification of host for "cro run" & "cro trace"

### DIFF
--- a/lib/Cro/Tools/CLI.pm6
+++ b/lib/Cro/Tools/CLI.pm6
@@ -195,15 +195,15 @@ multi MAIN('link', 'rm', $from-service-id, $to-service-id, $to-endpoint-id?) {
     rm-link($from-service-id, $to-service-id, $to-endpoint-id);
 }
 
-multi MAIN('run', Str:D :$host? = 'localhost') {
+multi MAIN('run', Str:D :$host = 'localhost') {
     run-services(:$host);
 }
 
-multi MAIN('run', *@service-name, Str:D :$host? = 'localhost') {
+multi MAIN('run', *@service-name, Str:D :$host = 'localhost') {
     run-services(filter => any(@service-name), :$host);
 }
 
-multi MAIN('trace', *@service-name-or-filter, Str:D :$host? = 'localhost') {
+multi MAIN('trace', *@service-name-or-filter, Str:D :$host = 'localhost') {
     my @service-name;
     my @trace-filters;
     for @service-name-or-filter {

--- a/lib/Cro/Tools/CLI.pm6
+++ b/lib/Cro/Tools/CLI.pm6
@@ -195,15 +195,15 @@ multi MAIN('link', 'rm', $from-service-id, $to-service-id, $to-endpoint-id?) {
     rm-link($from-service-id, $to-service-id, $to-endpoint-id);
 }
 
-multi MAIN('run') {
-    run-services();
+multi MAIN('run', Str:D :$host? = 'localhost') {
+    run-services(:$host);
 }
 
-multi MAIN('run', *@service-name) {
-    run-services(filter => any(@service-name));
+multi MAIN('run', *@service-name, Str:D :$host? = 'localhost') {
+    run-services(filter => any(@service-name), :$host);
 }
 
-multi MAIN('trace', *@service-name-or-filter) {
+multi MAIN('trace', *@service-name-or-filter, Str:D :$host? = 'localhost') {
     my @service-name;
     my @trace-filters;
     for @service-name-or-filter {
@@ -216,13 +216,13 @@ multi MAIN('trace', *@service-name-or-filter) {
     }
     run-services
         filter => @service-name ?? any(@service-name) !! *,
-        :trace, :@trace-filters;
+        :trace, :@trace-filters, :$host;
 }
 
-sub run-services(:$filter = *, :$trace = False, :@trace-filters) {
+sub run-services(:$filter = *, :$trace = False, :@trace-filters, :$host) {
     my $runner = Cro::Tools::Runner.new(
         services => Cro::Tools::Services.new(base-path => $*CWD),
-        :$filter, :$trace, :@trace-filters
+        :$filter, :$trace, :@trace-filters, :$host
     );
     react {
         my %service-id-colors;
@@ -247,16 +247,17 @@ sub run-services(:$filter = *, :$trace = False, :@trace-filters) {
                 my %endpoint-ports = .endpoint-ports;
                 for .cro-file.endpoints -> $endpoint {
                     my $port = %endpoint-ports{$endpoint.id};
+                    my $url-host = $host.contains(':') ?? "[" ~ $host ~ "]" !! $host;
                     print color($color) ~ "\c[ELECTRIC PLUG] Endpoint $endpoint.name() will be ";
                     given $endpoint.protocol {
                         when 'http' {
-                            say "at http://localhost:$port/" ~ RESET();
+                            say "at http://$url-host:$port/" ~ RESET();
                         }
                         when 'https' {
-                            say "at https://localhost:$port/" ~ RESET();
+                            say "at https://$url-host:$port/" ~ RESET();
                         }
                         default {
-                            say "on port $port" ~ RESET();
+                            say "on host $host port $port" ~ RESET();
                         }
                     }
                 }

--- a/lib/Cro/Tools/Runner.pm6
+++ b/lib/Cro/Tools/Runner.pm6
@@ -43,6 +43,7 @@ class Cro::Tools::Runner {
     has $.service-id-filter = *;
     has Bool $.trace = False;
     has Str @.trace-filters;
+    has Str:D $.host = 'localhost';
     has Supplier $!commands = Supplier.new;
 
     my enum State (StartedState => 1, WaitingState => 0, StoppedState => -1);
@@ -86,7 +87,7 @@ class Cro::Tools::Runner {
 
                 for $cro-file.links -> $link {
                     with $link.host-env {
-                        %env{$_} = 'localhost'
+                        %env{$_} = $!host;
                     }
                     with $link.port-env {
                         my $port = %services{$link.service}.endpoint-ports{$link.endpoint};
@@ -235,7 +236,7 @@ class Cro::Tools::Runner {
             my $next-try-port = 20000;
             sub free-port() {
                 loop {
-                    my $try-conn = IO::Socket::Async.connect('localhost', $next-try-port);
+                    my $try-conn = IO::Socket::Async.connect($!host, $next-try-port);
                     await Promise.anyof($try-conn, Promise.in(1));
                     if $try-conn.status == Kept {
                         $try-conn.result.close;
@@ -256,7 +257,7 @@ class Cro::Tools::Runner {
                 for $cro-file.env -> $_ { %env{.name} = .value }
                 for $cro-file.endpoints -> $endpoint {
                     with $endpoint.host-env {
-                        %env{$_} = 'localhost';
+                        %env{$_} = $!host;
                     }
                     with $endpoint.port-env {
                         %env{$_} = %endpoint-ports{$endpoint.id};


### PR DESCRIPTION
This allows users of the "cro" command line to (optionally) specify a host to listen on (rather than the default localhost). This is useful in dev environments where the dev machine is not the local workstation (like mine!).