### PR TITLE
Correct META6.json default provides section

### DIFF
--- a/lib/Cro/Tools/Template/HTTPService.pm6
+++ b/lib/Cro/Tools/Template/HTTPService.pm6
@@ -206,7 +206,7 @@ class Cro::Tools::Template::HTTPService does Cro::Tools::Template does Cro::Tool
     }
 
     method meta6-provides(%options) {
-        'Routes.pm6' => 'lib/Routes.pm6',
+        'Routes' => 'lib/Routes.pm6',
     }
 
     method docker-base-image(%options) {


### PR DESCRIPTION
Provides keys should be namespaces not filenames. Thus the ".pm6" part is
erroneous. This fixes `raku -I. t/some-router-test.t`