### PR TITLE
Test fixes

### DIFF
--- a/t/tools-crofile.t
+++ b/t/tools-crofile.t
@@ -345,7 +345,7 @@ throws-like { Cro::Tools::CroFile.parse: q:to/YAML/ },
 
     my $yaml;
     lives-ok { $yaml = $try-serialize.to-yaml() }, 'Serializing to YAML lives';
-    like $yaml, /'cro' \s* ':' \s* 1/, 'Has cro version identifier';
+    like $yaml, /'"'? 'cro' '"'? \s* ':' \s* 1/, 'Has cro version identifier';
 
     my $parsed;
     lives-ok { $parsed = Cro::Tools::CroFile.parse($yaml) }, 'Could parse output';

--- a/t/tools-link-editor.t
+++ b/t/tools-link-editor.t
@@ -11,8 +11,8 @@ chdir 't/tools-services-test-dir';
 lives-ok { add-link('service1', 'service2', 'http') }, 'Can add link';
 $current = slurp $service1;
 like $current,   /'"'? 'links'    '"'? ':' ' '* \n/, 'Links section is filled';
-like ($current), /'"'? 'host-env' '"'? ':' ' '* 'SERVICE2_HTTP_HOST'/, 'Host is added';
-like ($current), /'"'? 'port-env' '"'? ':' ' '* 'SERVICE2_HTTP_PORT'/, 'Port is added';
+like ($current), /'"'? 'host-env' '"'? ':' ' '* '"'? 'SERVICE2_HTTP_HOST' '"'?/, 'Host is added';
+like ($current), /'"'? 'port-env' '"'? ':' ' '* '"'? 'SERVICE2_HTTP_PORT' '"'?/, 'Port is added';
 
 lives-ok { rm-link('service1', 'service2', 'http') }, 'Can remove link';
 $current = slurp $service1;

--- a/t/tools-link-editor.t
+++ b/t/tools-link-editor.t
@@ -10,13 +10,13 @@ my $current = $content1;
 chdir 't/tools-services-test-dir';
 lives-ok { add-link('service1', 'service2', 'http') }, 'Can add link';
 $current = slurp $service1;
-like $current, /'links: ' \n/, 'Links section is filled';
-like ($current), /'host-env: SERVICE2_HTTP_HOST'/, 'Host is added';
-like ($current), /'port-env: SERVICE2_HTTP_PORT'/, 'Port is added';
+like $current,   /'"'? 'links'    '"'? ':' ' '* \n/, 'Links section is filled';
+like ($current), /'"'? 'host-env' '"'? ':' ' '* 'SERVICE2_HTTP_HOST'/, 'Host is added';
+like ($current), /'"'? 'port-env' '"'? ':' ' '* 'SERVICE2_HTTP_PORT'/, 'Port is added';
 
 lives-ok { rm-link('service1', 'service2', 'http') }, 'Can remove link';
 $current = slurp $service1;
-like   ($current), /'links:  []'/, 'Links section is empty';
+like   ($current), /'"'? 'links' '"'? ':' ' '* '[]'/, 'Links section is empty';
 unlike ($current), /'SERVICE2_HTTP_HOST'/, 'Host is removed';
 unlike ($current), /'SERVICE2_HTTP_PORT'/, 'Port is removed';
 

--- a/t/tools-link-editor.t
+++ b/t/tools-link-editor.t
@@ -18,7 +18,7 @@ lives-ok { rm-link('service1', 'service2', 'http') }, 'Can remove link';
 $current = slurp $service1;
 like   ($current), /'links:  []'/, 'Links section is empty';
 unlike ($current), /'SERVICE2_HTTP_HOST'/, 'Host is removed';
-unlike ($current), /'SERVICE2_HTTP_PORt'/, 'Port is removed';
+unlike ($current), /'SERVICE2_HTTP_PORT'/, 'Port is removed';
 
 # Restore state
 spurt $service1, $content1;


### PR DESCRIPTION
The first commit is a trivial typo fix that had been invalidating the test (it would always succeed, because it used `unlike`).

The second commit loosens some regexen to allow optional double quotes around YAML map keys, as this seems to be the behavior with certain versions of the YAML codecs, and is causing tests and CI to fail depending on installed YAML codec version.