### PR TITLE
Fix tests on macOS

### DIFF
--- a/t/tools-runner.rakutest
+++ b/t/tools-runner.rakutest
@@ -6,7 +6,7 @@ use Shell::Command;
 use Test;
 
 sub with-test-dir(&test-case) {
-    my $temp-dir = "$*TMPDIR/cro-test-{(0..9).roll(40).join}";
+    my $temp-dir = $*TMPDIR.add("cro-test-{(0..9).roll(40).join}");
     mkdir $temp-dir;
     cp 't/tools-services-test-dir', $temp-dir, :r;
     LEAVE rm_rf $temp-dir;

--- a/t/tools-services.rakutest
+++ b/t/tools-services.rakutest
@@ -3,7 +3,7 @@ use Shell::Command;
 use Test;
 
 sub with-test-dir(&test-case) {
-    my $temp-dir = "$*TMPDIR/cro-test-{(0..9).roll(40).join}";
+    my $temp-dir = $*TMPDIR.add("cro-test-{(0..9).roll(40).join}");
     mkdir $temp-dir;
     cp 't/tools-services-test-dir', $temp-dir, :r;
     LEAVE rm_rf $temp-dir;


### PR DESCRIPTION
The paths contained // and so didn't compare properly. The IO::Path.add method avoids this issue.

There's still an issue where it says `t/tools-runner.rakutest .......1/?# Check service up attempt 1: connection refused`, but the tests pass and that seems to be expected by the test?