### PR TITLE
fix links in readme, add --/test back to install intsruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This is part of the Cro libraries for implementing services and distributed
 systems in Raku. See the [Cro website](https://cro.services/) for further
 information and documentation.
 
-This repository contains the [`cro` command line tool], as well as the sources for the Cro documentation included in the [Cro website](http://cro.services/) for further
-information and documentation in the [`doc`](/doc) directory.
+This repository contains the [`cro` command line tool](/docs/cro-tool.md), as well as the sources for the Cro documentation included in the [Cro website](http://cro.services/) for further
+information and documentation in the [`docs`](/docs/index.md) directory.
 
 ## Install
 
 Install this using zef
 
-    zef install cro
+    zef install --/test cro


### PR DESCRIPTION
"cro commandline tool" was not a link, and doc link should be docs instead

this pull request does not (yet) fix links between the files in docs/ to link to each other properly; currently they all link to "docs/docs/blabla"

I also decided to add --/test back to the installation instructions (https://cro.services also has this on the front page)