### PR TITLE
Try a newer "oldest" raku version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 #          - macOS-latest
 #          - windows-latest
         raku-version:
-          - "2021.03"
+          - "2022.01"
           - "latest"
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 #          - macOS-latest
 #          - windows-latest
         raku-version:
-          - "2022.01"
+          - "2022.02"
           - "latest"
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
the current 2021.03 seems to have trouble with Digest::SHA2 where it tries to unbox a 64bit wide bigint to an integer and fails (signed/unsigned related maybe?)